### PR TITLE
fixed missing rolesUserAttribute usage

### DIFF
--- a/Security/LdapUserProvider.php
+++ b/Security/LdapUserProvider.php
@@ -175,7 +175,7 @@ class LdapUserProvider implements UserProviderInterface
     private function getLdapRoles(Entry $entry)
     : array {
         $rolesBaseDn = empty($this->rolesOuFilter) ? $this->baseDn : $this->rolesOuFilter . ',' . $this->baseDn;
-        $rolesFilter = sprintf('(&%s(member=%s))', $this->rolesFilter, $entry->getDn());
+	    $rolesFilter = sprintf('(&%s(%s=%s))', $this->rolesFilter, $this->rolesUserAttribute, $entry->getDn());
         $search = $this->ldapConnection->query($rolesBaseDn, $rolesFilter, ['filter' => ['cn']]);
         $entries = $search->execute();
 

--- a/Security/LdapUserProviderFactory.php
+++ b/Security/LdapUserProviderFactory.php
@@ -41,7 +41,7 @@ class LdapUserProviderFactory implements UserProviderFactoryInterface
                 ->scalarNode('uid_key')->defaultValue('sAMAccountName')->end()
                 ->scalarNode('filter')->defaultValue('({uid_key}={username})')->end()
                 ->scalarNode('roles_ou_filter')->defaultNull()->end()
-                ->scalarNode('roles_user_attribute')->defaultNull()->end()
+                ->scalarNode('roles_user_attribute')->defaultValue('member')->end()
             ->end()
         ;
     }


### PR DESCRIPTION
Hi,

I was trying to change the roles_user_attribute attribute to use the LDAP_MATCHING_RULE_IN_CHAIN and search the users groups recursively but I've noticed that it wasn't working.

Digging through the code I've noticed that is not used anywhere, so I've inserted it in the query and given to that the default of "member" like before and I've tested that it's fully working.
I've also tested using the configuration roles_user_attribute: 'member:1.2.840.113556.1.4.1941:' that does the recursive search and it works.

Hope this can be merged.
Thanks